### PR TITLE
Revised exercise to better respect Learners.

### DIFF
--- a/modules/JavaScript-in-the-Browser/exercises/Mac-Calculator-Clone/README.md
+++ b/modules/JavaScript-in-the-Browser/exercises/Mac-Calculator-Clone/README.md
@@ -1,27 +1,40 @@
-# Mac Calculator Clone
-
+# Mac Calculator Reimplementation
 
 ## Description
 
-Replicate the built-in Mac calculator as a web app.
+Reimplement the built-in Mac calculator as a web app.
 
-This goal has 3 linear stages. You must complete the specs of each stage before
+This goal has 2 (or 3) linear stages. You must complete the specs of each stage before
 progressing onto the next.
 
 ## Setup
 
 1. Create a new repository
 0. Within it create the files: `index.html`, `index.css`, and `index.js`
-0. Do your best to clone the Mac Calculator
+0. Do your best to reimplement the (basic version of the) Mac OS X Calculator
 
 
 ## Stage 1
 
-In stage 1 you will only be using `HTML` and `CSS` to build a clone of the OS X
-calculator interface. You're only building the interface in this stage. You'll
+In stage 1 you will only be using `HTML` and `CSS` to build the interface of your
+calculator. You're only building the interface in this stage. You'll make the
 make the calculator work in stage 2.
 
+Here is an example of what your interface might look like.
+
 ![calculator-in-browser](https://cloud.githubusercontent.com/assets/8385/22572099/6786dd74-e957-11e6-9340-278e63aa3809.png)
+
+But that isn't the only possible appearance. You will be reimplementing the Mac calculator, which implies
+deciding how faithful to the original your version will be. Give that question some thought, and do some research to
+help you make an informed decision. The Mac calculator has changed over time, and there have been criticisms
+of both the look-and-feel and the functionality of this application (and its competitors). See, for example:
+
+http://lowendmac.com/2015/mac-calculators-from-jobsian-simplicity-to-eye-candy/
+https://apple.stackexchange.com/questions/214839/how-to-solve-the-issue-of-on-calculator-giving-different-results-on-iphone-v
+https://github.com/jrpool/calculator
+http://stulta.com/forumo/archives/2089
+http://www.harold.thimbleby.net/cv/files/hucalc.pdf
+
 
 ### In this stage you will be using at least the following skills:
 
@@ -46,7 +59,7 @@ make the calculator work in stage 2.
 - NOT use `<form>` tags
 - NOT use `<input>` tags
 
-### You're done when…
+### Unless your design requires exceptions, you're done when…
 
 - All text is in the [Roboto](https://fonts.google.com/specimen/Roboto) web font
 - Your `HTML` and `CSS` follows this [style guide](https://google.github.io/styleguide/htmlcssguide.html)
@@ -57,6 +70,7 @@ make the calculator work in stage 2.
 - Each button has a CSS transition, lasting 100ms, to a slightly darker background color on click
 - All class names re: the calculator are name-spaced under `.calculator-…`
 - Your stylesheet contains little to no duplicate style declarations
+- Your README.md file describes and motivates any improvements you have made to the original calculator’s look and feel
 
 ## Stage 2
 
@@ -64,7 +78,7 @@ In stage 2 you will be adding `JavaScript` to make the calculator work.
 
 ### In this stage you will be using at least the following skills:
 
-- ES5 syntax
+- ES5 syntax (for maximum cross-browser compatibility)
 - Registering event listeners
 - Binding to the DOM Ready event
 - JavaScript closures
@@ -80,47 +94,25 @@ In stage 2 you will be adding `JavaScript` to make the calculator work.
 
 - Store the state of your calculator in `JavaScript`
 - NOT use `jQuery` or any other `JavaScript` libraries or frameworks
-- NOT use `ES6`
+- NOT use features introduced in `ES2015`
 - NOT store or read state from the DOM
 
-### You're done when…
+### Unless your design requires exceptions, you're done when…
 
 - Your `JavaScript` is written in `ES5`
 - Your `JavaScript` follows this [style guide](https://google.github.io/styleguide/jsguide.html)
-- Your JavaScript defines 1 or less global variables
+- Your JavaScript defines no more than 1 global variable
 - Typing a relevant key at any point is reflected on the calculator
-- Typing a relevant key causes the corresponding button on the calculator to appear to have been pressed. AKA flashes active
-- The state of the calculator is not be stored in the `DOM`
+- Typing a relevant key causes the corresponding button on the calculator to flash active, thus appearing to have been pressed
+- The state of the calculator is not stored in the `DOM`
 - The mathematical operations for your calculator are each their own function, and are defined outside of any DOM event handler
-- When the length of the number displayed exceeds the width available, the font-size deterministically drops
+- The font size decreases as needed to fit long numbers
+- The calculator calculates consistently and intuitively
+- Your README.md file describes and motivates any improvements you have made to the original calculator’s operating rules
 
-Calculator functionality and behavior is consistent with [Mac calculator rules](#calculator-rules-and-examples):
+## Stage 3--Stretch
 
-- pressing `AC` displays `0`
-- pressing `AC` `8` `+/-` displays `-8`
-- pressing `AC` `-5` `+/-` displays `5`
-- pressing `AC` `99` `%` displays `0.99`
-- pressing `AC` `9` `+` `9` `-` `3` `=` displays `15`
-- pressing `AC` `6` `+` `=` displays `12`
-- pressing `AC` `4` `x` `4` `=` displays `16`
-- pressing `AC` `64` `+` `=` displays `128`
-- pressing `AC` `9` `+` displays `9`
-- pressing `AC` `8` `-` `5` `-` displays `3`
-- pressing `AC` `9` `-` `5` `+` displays `4`
-- pressing `AC` `9` `+` `9` `+` `+` `+` displays `18`
-- pressing `AC` `5` `+` `3` `x` `6` `+` displays `23`
-- pressing `AC` `9` `x` displays `9`
-- pressing `AC` `3` `x` `5` `x` displays `15`
-- pressing `AC` `6` `/` `3` displays `2`
-- pressing `AC` `3` `x` `4` `x` `x` `x` displays `12`
-- pressing `AC` `4` `+` `3` `x` `6` `x` displays `18`
-- pressing `AC` `3` `+` `5` `x` displays `5`
-- pressing `AC` `3` `+` `5` `x` `6` `x` displays `30`
-- pressing `AC` `3` `+` `5` `x` `6` `x` `2` `+` displays `63`
-
-### Stage 3
-
-In stage 3 you are going to add a second calculator to the page. Both calculators will be exactly the same but work independently. This will likely require you to refactor some of the JavaScript you wrote in stage 2.
+In stage 3 you are going to add a second calculator to the page. Both calculators will be exactly the same but work independently. This will likely require you to refactor some of the JavaScript you wrote in stage 2. Here is an example:
 
 ![two-calculators-in-browser](https://cloud.githubusercontent.com/assets/8385/22572109/72df42ba-e957-11e6-8c9e-c9efd39045c1.png)
 
@@ -139,11 +131,11 @@ In stage 3 you are going to add a second calculator to the page. Both calculator
 - consider using a constructor called `Calculator`
 - NOT give each calculator a unique `id` or `classname`
 
-### You're done when…
+### Unless your design requires exceptions, you're done when…
 
 - Each calculator acts independently.
 - Clicking anywhere on a calculator focuses that calculator.
 - Typing a relevant key affects the focused calculator.
-- Use event delegation to avoid binding a `click` event listener to each button
+- You use event delegation to avoid binding a `click` event listener to each button
 - The focused calculator is `opacity: 1`
 - The not-focused calculator is `opacity: 0.5`

--- a/modules/JavaScript-in-the-Browser/exercises/Mac-Calculator-Clone/README.md
+++ b/modules/JavaScript-in-the-Browser/exercises/Mac-Calculator-Clone/README.md
@@ -29,12 +29,13 @@ deciding how faithful to the original your version will be. Give that question s
 help you make an informed decision. The Mac calculator has changed over time, and there have been criticisms
 of both the look-and-feel and the functionality of this application (and its competitors). See, for example:
 
+```
 http://lowendmac.com/2015/mac-calculators-from-jobsian-simplicity-to-eye-candy/
 https://apple.stackexchange.com/questions/214839/how-to-solve-the-issue-of-on-calculator-giving-different-results-on-iphone-v
 https://github.com/jrpool/calculator
-http://stulta.com/forumo/archives/2089
+http://stulta.com/forumo/archives/2089#calc
 http://www.harold.thimbleby.net/cv/files/hucalc.pdf
-
+```
 
 ### In this stage you will be using at least the following skills:
 

--- a/modules/JavaScript-in-the-Browser/exercises/Mac-Calculator-Clone/README.md
+++ b/modules/JavaScript-in-the-Browser/exercises/Mac-Calculator-Clone/README.md
@@ -18,7 +18,7 @@ progressing onto the next.
 
 In stage 1 you will only be using `HTML` and `CSS` to build the interface of your
 calculator. You're only building the interface in this stage. You'll make the
-make the calculator work in stage 2.
+calculator work in stage 2.
 
 Here is an example of what your interface might look like.
 


### PR DESCRIPTION
Reference to Mac calculator’s rules was a dead link. Those rules do not seem to be available, and, in any case, the application does not deserve to be cloned. Revised version aims to respect Learners’ intelligence, creativity, and ambition, giving them a taste of the fact that they can improve on even huge enterprises’ applications. Amount of work for all 3 stages was disproportional for 1 exercise of 1 module in Phase 2, so Stage 3 has been defined as a stretch goal.

I have checked the history of this exercise back to October 2016. It was a 1-week goal with 5 and then 4 stages before the curriculum reform, and during 2017 it was assigned to 47 projects. About a quarter of those working on it repeated it for a second or even a third week. No more than two of these projects resulted in fully working calculators. About 6 others partly work. Now the goal has been demoted to a mere exercise within a module. It was over-ambitious before, and it is even more so now.

The projects with fully or partly working calculators (at least some buttons work) are:
https://github.com/ian-deans/calculator2
https://github.com/FrankieFabuloso/gleaming-dragonfly-calculator
https://github.com/erikasf/mac-calculator-clone
https://github.com/mKleinCreative/mac-calculator-clone
https://github.com/sdweber422/mac-calculator-clone/tree/2nd-attempt-master
https://github.com/zubairnahmed/Week-13-Mac-Calculator-Clone
https://github.com/lumodon/mac-calculator-clone
https://github.com/helenyau0/mac-calculator-clone