### PR TITLE
add /lectures page to list all youtube videos

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4537,13 +4537,9 @@
       }
     },
     "node-fetch": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ==",
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ=="
     },
     "node-gyp": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "marked": "^0.3.6",
     "moment": "^2.18.1",
     "newrelic": "^2.0.0",
+    "node-fetch": "^1.7.3",
     "pg": "^6.2.4",
     "pug": "^2.0.0-rc.2",
     "pygmentize-bundled": "^2.3.0",

--- a/web-server/assets/src/browser.sass
+++ b/web-server/assets/src/browser.sass
@@ -3,3 +3,4 @@
 @import "./style/users"
 @import "./style/modules"
 @import "./style/skills"
+@import "./style/lectures"

--- a/web-server/assets/src/style/lectures.sass
+++ b/web-server/assets/src/style/lectures.sass
@@ -1,0 +1,6 @@
+.lectures-nav
+  display: flex
+  justify-content: center
+
+.lectures-title
+  width: 280px

--- a/web-server/index.js
+++ b/web-server/index.js
@@ -36,6 +36,7 @@ require('./routes/calendar')(app)
 require('./routes/cos')(app)
 require('./routes/backoffice')(app)
 require('./routes/profile')(app)
+require('./routes/lectures')(app)
 
 app.get('/', (request, response, next) => {
   response.renderMarkdownFile(`/README.md`)

--- a/web-server/routes/lectures.js
+++ b/web-server/routes/lectures.js
@@ -1,0 +1,32 @@
+const fetch = require('node-fetch')
+const qs = require('querystring')
+const API_KEY = process.env.YOUTUBE_API_KEY
+const URL = 'https://www.googleapis.com/youtube/v3/playlistItems'
+
+const generateApiUrl = function(pageToken) {
+  const query = qs.stringify({
+    part: 'snippet',
+    maxResults: '48',
+    playlistId: 'UU599lkzf-2haPTzDAMGEgLg',
+    key: API_KEY,
+    pageToken,
+  })
+  return `${URL}?${query}`
+}
+
+module.exports = app => {
+  app.get('/lectures(/:pageToken)?', (request, response, next) => {
+    const { pageToken } = request.params
+    const url = generateApiUrl(pageToken)
+    fetch(url)
+      .then(function(res) {
+          return res.json();
+      }).then(function(json) {
+          app.locals.nextPageToken = json.nextPageToken || ''
+          app.locals.prevPageToken = json.prevPageToken || ''
+          const videos = json.items.map(video => video.snippet)
+          response.render('lectures', { title: 'Lectures', videos })
+      })
+      .catch(next)
+  })
+}

--- a/web-server/views/lectures.jade
+++ b/web-server/views/lectures.jade
@@ -1,0 +1,29 @@
+extends layout
+
+block content
+  h1 Lectures
+  - var url = 'https://www.youtube.com/watch?v='
+  table.table
+    thead
+      tr
+        th
+        th Title
+        th Description
+    tbody
+    each video in videos
+        tr
+          th(scope='row')
+            a(href=`${url + video.resourceId.videoId}` target='_blank')
+              img(src=`${video.thumbnails.default.url}`)
+          td.lectures-title
+            a(href=`${url + video.resourceId.videoId}` target='_blank') #{video.title}
+          td #{video.description}
+
+  nav(aria-label='Search Results').lectures-nav
+    ul.pagination
+      if prevPageToken
+        li.page-item
+          a.page-link(href=`/lectures/${prevPageToken}`) Prev Page
+      if nextPageToken
+        li.page-item
+          a.page-link(href=`/lectures/${nextPageToken}`) Next Page

--- a/web-server/views/navbar.jade
+++ b/web-server/views/navbar.jade
@@ -55,6 +55,9 @@ nav.navbar.navbar-inverse(role='navigation')
         li.dropdown
           a(href='/calendar') Calendar
 
+        li.dropdown.hidden-sm
+          a(href='/lectures') Lectures
+
         if process.env.NODE_ENV === 'development'
           li.dropdown
             a(href='/digest') Digest


### PR DESCRIPTION
Fixes #291 

Notes:
- Tags are not included as one of the returned properties. Currently the only way to get tags would be to do the initial hit to the api, then get all of the video id's and append those to a second request to the api. https://stackoverflow.com/questions/41943656/get-tags-for-a-youtube-video-and-search-youtube-videos-by-tag

- There looks to be no set standard for the way videos are uploaded therefore some videos are missing properties. For example, You are actually the only person who includes tags. 

- We included the avatar in this iteration so you could see how it looks. 