### PR TITLE
Removes duplicate link from 'Party Like Its ES2017' Module

### DIFF
--- a/modules/Party-Like-Its-ES2017/README.md
+++ b/modules/Party-Like-Its-ES2017/README.md
@@ -24,10 +24,6 @@ webpack express tutorial -React
 
 ## Resources
 
-### Watch
-
-- https://www.youtube.com/watch?v=LtEP_-3a5CY
-
 ### Read
 
 - http://node.green/


### PR DESCRIPTION
There were two links to the same route on the 'Party Like Its ES2017' Module.
This PR removes one of them.