### PR TITLE
BUG FIX: Corrected erroneous value

### DIFF
--- a/database/queries.js
+++ b/database/queries.js
@@ -16,7 +16,7 @@ const getCheckLogsForUsers = userIds => {
   return knex
     .select('*')
     .from('event_logs')
-    .where('type', 'check')
+    .where('type', 'skill_check')
     .whereIn('user_id', userIds)
     .orderBy('occurred_at', 'asc')
     .then(checkLogs => {


### PR DESCRIPTION
All seed test data have “skill_check” as the value of “type”. This change is based on the assumption that “skill_check” is the desired value. Tests for issue 376 are being created on the basis of that same assumption.